### PR TITLE
Fix: Update version to 0.2.0 for PyPI publish

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qwenvert"
-version = "0.1.0"
+version = "0.2.0"
 description = "One-click local LLM inference for Claude Code on Mac M1"
 readme = "README.md"
 requires-python = ">=3.9,<3.13"


### PR DESCRIPTION
## Summary
- Fix version mismatch that caused PyPI publish workflow to fail
- Update `pyproject.toml` version from 0.1.0 to 0.2.0 to match the v0.2.0 git tag

## Context
The publish workflow failed with:
```
❌ Version mismatch!
Git tag: v0.2.0
pyproject.toml: 0.1.0
```

This PR resolves the mismatch so the package can be published to PyPI successfully.

## Test plan
- [x] Verify pyproject.toml version is now 0.2.0
- [ ] Verify workflow passes after merge
- [ ] Verify package publishes to PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.2.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->