### PR TITLE
Add virtual environment support for macOS PEP 668 compatibility

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,17 +70,43 @@ git remote add upstream https://github.com/kmesiab/qwenvert.git
 
 ### 2. Set Up Development Environment
 
+**macOS Python 3.11+ Users:** Modern macOS uses system-protected Python (PEP 668). Always use a virtual environment for development.
+
+#### Quick Setup (Recommended)
+
 ```bash
-# Create virtual environment
-python3 -m venv venv
-source venv/bin/activate
+# Create and activate virtual environment
+make venv
+source .venv/bin/activate
 
-# Install in development mode
-pip install -e .
+# Install qwenvert in editable mode + dev dependencies
+make install-dev
 
-# Install development dependencies
-pip install pytest pytest-asyncio httpx black isort mypy
+# Verify installation
+qwenvert --version
 ```
+
+#### Manual Setup (Alternative)
+
+```bash
+# Create virtual environment manually
+python3 -m venv .venv
+source .venv/bin/activate  # macOS/Linux
+
+# Install development dependencies (includes qwenvert)
+pip install -e ".[dev]"
+```
+
+**Verify your environment:**
+```bash
+# Should show .venv Python, not system Python
+which python3
+
+# Should show "pip" from .venv
+which pip
+```
+
+**Note:** The virtual environment is gitignored (`.venv/` in `.gitignore`).
 
 ### 3. Create a Feature Branch
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install install-dev clean lint format typecheck test test-unit test-integration coverage check-all benchmark build publish-test publish release
+.PHONY: help install install-dev clean lint format typecheck test test-unit test-integration coverage check-all benchmark build publish-test publish release venv check-venv
 
 PYTHON ?= python3
 
@@ -7,8 +7,9 @@ help:
 	@echo "qwenvert - Development Commands"
 	@echo ""
 	@echo "Setup:"
+	@echo "  make venv             Create virtual environment at .venv/"
 	@echo "  make install          Install production dependencies"
-	@echo "  make install-dev      Install development dependencies"
+	@echo "  make install-dev      Install development dependencies (requires venv)"
 	@echo ""
 	@echo "Code Quality:"
 	@echo "  make format           Format code with black and ruff"
@@ -38,8 +39,40 @@ help:
 install:
 	$(PYTHON) -m pip install -e .
 
-install-dev:
+install-dev: check-venv
 	$(PYTHON) -m pip install -e ".[dev]"
+
+# Virtual environment helpers
+venv:
+	@echo "Creating virtual environment..."
+	$(PYTHON) -m venv .venv
+	@echo "✓ Virtual environment created at .venv/"
+	@echo ""
+	@echo "Activate it with:"
+	@echo "  source .venv/bin/activate      # bash/zsh"
+	@echo "  source .venv/bin/activate.fish # fish"
+	@echo ""
+	@echo "Then install dependencies:"
+	@echo "  make install-dev"
+
+check-venv:
+	@if [ -n "$$CI" ]; then \
+		: ; \
+	elif $(PYTHON) -c "import sys; exit(0 if sys.prefix != sys.base_prefix else 1)" 2>/dev/null; then \
+		: ; \
+	else \
+		echo "⚠️  Warning: Not in a virtual environment!"; \
+		echo ""; \
+		echo "Create one with:"; \
+		echo "  make venv"; \
+		echo ""; \
+		echo "Or use conda/poetry if preferred."; \
+		echo ""; \
+		echo "Then activate and retry:"; \
+		echo "  source .venv/bin/activate"; \
+		echo "  make install-dev"; \
+		exit 1; \
+	fi
 
 # Code formatting
 format:

--- a/README.md
+++ b/README.md
@@ -45,6 +45,25 @@ cd qwenvert
 pip install -e .
 ```
 
+> **macOS Users (Python 3.11+):** If you see an "externally-managed-environment" error, you have two options:
+>
+> **Option 1 (Recommended for development):**
+> ```bash
+> git clone https://github.com/kmesiab/qwenvert.git
+> cd qwenvert
+> make venv           # Creates .venv virtual environment
+> source .venv/bin/activate
+> make install-dev    # Installs qwenvert + dev dependencies
+> ```
+>
+> **Option 2 (Recommended for end users):**
+> ```bash
+> pipx install qwenvert  # Installs in isolated environment
+> # Install pipx first if needed: brew install pipx
+> ```
+>
+> This is due to [PEP 668](https://peps.python.org/pep-0668/) which protects system Python on modern macOS.
+
 ### 2. Setup (One Command)
 
 ```bash
@@ -449,6 +468,49 @@ export ANTHROPIC_MODEL=qwenvert-default
 # Save and reload
 source ~/.zshrc
 ```
+
+---
+
+### "externally-managed-environment" error on install
+
+**Problem:** `pip install` fails with error about externally managed environment
+
+**macOS Python 3.11+ Context:** Apple now protects system Python to prevent breaking macOS tools. This is [PEP 668](https://peps.python.org/pep-0668/) in action.
+
+**Solution 1 - Virtual Environment (Recommended for development):**
+```bash
+# Clone the repository
+git clone https://github.com/kmesiab/qwenvert.git
+cd qwenvert
+
+# Create and activate virtual environment
+make venv
+source .venv/bin/activate
+
+# Install
+make install-dev
+```
+
+**Solution 2 - pipx (Recommended for end users):**
+```bash
+# Install pipx if needed
+brew install pipx
+
+# Install qwenvert in isolated environment
+pipx install qwenvert
+```
+
+**Solution 3 - Disable protection (NOT recommended):**
+```bash
+# This breaks the system protection - avoid unless you know what you're doing
+pip install qwenvert --break-system-packages
+```
+
+**Why virtual environments?**
+- Isolated dependencies (won't conflict with other projects)
+- Easy to delete and recreate if something breaks
+- Standard Python best practice
+- Doesn't require disabling system protections
 
 ---
 


### PR DESCRIPTION
Fixes the "externally-managed-environment" error that macOS Python 3.11+ users encounter when trying to install qwenvert.

## Problem

macOS Python 3.11+ implements [PEP 668](https://peps.python.org/pep-0668/) which prevents system-wide `pip install` to protect the OS. New contributors and users hit this error immediately with no clear guidance.

## Solution

Added comprehensive virtual environment support with three components:

### 1. Makefile Targets

**New Commands:**
- `make venv` - Creates `.venv` virtual environment with helpful activation instructions
- `make check-venv` - Verifies virtual environment is active before installing
- `make install-dev` - Now requires venv (with CI bypass for GitHub Actions)

**Key Features:**
- ✅ **CI/CD compatible** - Detects `$CI` variable, won't break GitHub Actions
- ✅ **Universal detection** - Works with venv, conda, poetry, pdm (uses Python `sys.prefix != sys.base_prefix`)
- ✅ **Clear error messages** - Shows exactly what command to run
- ✅ **Non-breaking** - `make install` still works without venv requirement

### 2. Documentation Updates

**CONTRIBUTING.md:**
- Replaced manual venv setup with `make venv` workflow
- Added verification steps (`which python3`, `which pip`)
- Explains PEP 668 context for macOS users

**README.md:**
- Warning box in install section with two options:
  - **Developers:** `make venv` + `make install-dev`
  - **End users:** `pipx install qwenvert` (isolated environment)
- New troubleshooting section explaining:
  - What PEP 668 is and why it exists
  - Three solutions (venv recommended, pipx alternative, --break-system-packages discouraged)
  - Benefits of virtual environments

### 3. Agent Review

Consulted specialized agents before implementation:
- **qwenvert-reviewer:** Identified CI compatibility issue, recommended Python-based detection
- **doc-maintainer:** Suggested dual-audience documentation (developers vs end users)

All recommendations implemented.

## Changes

- **Makefile**: +39 lines (venv targets + help text)
- **CONTRIBUTING.md**: +33 lines (updated setup instructions)
- **README.md**: +62 lines (warning box + troubleshooting)

**Total**: 131 insertions, 10 deletions

## Testing

Manually tested:
- ✅ `make venv` creates `.venv` directory
- ✅ `make check-venv` detects when not in venv (clear error)
- ✅ `make check-venv` passes when in venv
- ✅ Works with conda environments
- ✅ Help text displays correctly

CI compatibility verified through code review (checks `$CI` variable).

## User Impact

**Before:**
```bash
pip install qwenvert
# error: externally-managed-environment
# ❌ No clear solution
```

**After:**
```bash
make venv
source .venv/bin/activate
make install-dev
# ✅ Clear workflow, helpful error messages
```

Fixes the primary onboarding pain point for macOS developers on Python 3.11+.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added make targets to create and verify a Python virtual environment and to require a venv before installing dev dependencies.

* **Documentation**
  * Added macOS-specific Python 3.11+ setup (Quick and Manual), environment verification steps, and note that the venv is gitignored.
  * Added troubleshooting/FAQ for the “externally-managed-environment” error with multiple solutions and recommended approach.
  * Expanded Privacy & Security section with explicit guarantees that all processing and data remain local.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->