### PR TITLE
Fix: Resolve artifact upload conflict in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -140,6 +140,7 @@ jobs:
         with:
           name: python-package-distributions
           path: dist/
+          overwrite: true
 
       - name: Create release summary
         run: |


### PR DESCRIPTION
## Summary
- Add `overwrite: true` to artifact upload in publish workflow
- Fixes 409 Conflict error when build and publish jobs upload same artifact

## Problem
The v0.2.1 release workflow showed as "failed" even though PyPI publish succeeded:
```
Error: Failed to CreateArtifact: Received non-retryable error: 
Failed request: (409) Conflict: an artifact with this name already exists
```

## Root Cause
Both jobs upload artifacts with same name:
1. Build Package → uploads `python-package-distributions`  
2. Publish to PyPI → tries to upload `python-package-distributions` again ❌

## Solution
Add `overwrite: true` to allow the publish job to overwrite the artifact.

## Test Plan
- [x] Verify fix in workflow file
- [ ] Next release should complete without artifact conflict

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the PyPI publish workflow to improve artifact handling during the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->