### PR TITLE
Fix CI test failure: Use active Python in CI environments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,21 @@
 .PHONY: help install install-dev clean lint format typecheck test test-unit test-integration coverage check-all benchmark build publish-test publish release venv check-venv check-python
 
 # Auto-detect compatible Python version (3.9-3.12)
-# Try specific versions first, fall back to python3
+# In CI, use the active Python; otherwise, try specific versions
 PYTHON ?= $(shell \
-	for py in python3.12 python3.11 python3.10 python3.9 python3; do \
-		if command -v $$py >/dev/null 2>&1; then \
-			version=$$($$py -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")' 2>/dev/null); \
-			if [ "$$version" = "3.9" ] || [ "$$version" = "3.10" ] || [ "$$version" = "3.11" ] || [ "$$version" = "3.12" ]; then \
-				echo $$py; \
-				break; \
+	if [ -n "$$CI" ]; then \
+		echo python; \
+	else \
+		for py in python3.12 python3.11 python3.10 python3.9 python3; do \
+			if command -v $$py >/dev/null 2>&1; then \
+				version=$$($$py -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")' 2>/dev/null); \
+				if [ "$$version" = "3.9" ] || [ "$$version" = "3.10" ] || [ "$$version" = "3.11" ] || [ "$$version" = "3.12" ]; then \
+					echo $$py; \
+					break; \
+				fi; \
 			fi; \
-		fi; \
-	done)
+		done; \
+	fi)
 
 # Default target
 help:


### PR DESCRIPTION
## Problem

The publish workflow test job was failing with:

```
Running tests with coverage...
python3.12 -m pytest
/usr/local/bin/python3.12: No module named pytest
make: *** [test] Error 1
Error: Process completed with exit code 2.
```

## Root Cause

**Mismatch between setup-python and Makefile:**

1. CI workflow uses `setup-python@v5` to install Python 3.11
2. Dependencies (`pytest`, etc.) are installed in Python 3.11
3. Makefile auto-detection logic tries versions in order: **python3.12** first
4. macOS runners have system python3.12 at `/usr/local/bin/python3.12`
5. Makefile uses python3.12 (without dependencies) instead of python 3.11 (with dependencies)
6. Tests fail because pytest isn't installed in python3.12

## Solution

Detect CI environment and use the **active Python** instead of searching:

```makefile
# Before:
PYTHON ?= $(shell \
  for py in python3.12 python3.11 ...; do
    # Always searches, even in CI
  done)

# After:
PYTHON ?= $(shell \
  if [ -n "$$CI" ]; then
    echo python;  # Use active Python (from setup-python)
  else
    # Auto-detect for local development
  fi)
```

## Behavior

| Environment | Python Used | Why |
|-------------|------------|-----|
| **CI** | `python` | Respects `setup-python` action (3.11 with deps) |
| **Local** | `python3.12` | Auto-detects compatible version (3.9-3.12) |

## Impact

✅ CI tests now pass (uses correct Python with dependencies)  
✅ Local development unchanged (still auto-detects)  
✅ Works with any `setup-python` version (3.9-3.12)  
✅ No breaking changes

## Testing

**CI behavior:**
```bash
CI=true make test
# Uses: python -m pytest ✅
```

**Local behavior:**
```bash
make test
# Uses: python3.12 -m pytest ✅
```

## Related

Fixes the test job failure in the publish workflow (`.github/workflows/publish.yml`).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)