### PR TITLE
Bump version to 0.2.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qwenvert"
-version = "0.2.1"
+version = "0.2.2"
 description = "One-click local LLM inference for Claude Code on Mac M1"
 readme = "README.md"
 requires-python = ">=3.9,<3.13"

--- a/qwenvert/__init__.py
+++ b/qwenvert/__init__.py
@@ -5,7 +5,7 @@ A production-grade inference orchestration system optimized for consumer
 Mac hardware running Qwen models with Claude Code integration.
 """
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 __author__ = "Kevin Mesiab"
 
 from .hardware import HardwareDetector, HardwareProfile


### PR DESCRIPTION
## Summary
Synchronize repository version numbers for v0.2.2 release.

## Changes
- Update `pyproject.toml` version to 0.2.2
- Update `qwenvert/__init__.py` version to 0.2.2

## Release Status
- ✅ Tag v0.2.2 created
- ✅ GitHub Release published: https://github.com/kmesiab/qwenvert/releases/tag/v0.2.2
- ✅ Published to PyPI: https://pypi.org/project/qwenvert/0.2.2/

This PR brings the main branch in sync with the published release.

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated package version to 0.2.2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->