### PR TITLE
Fix: Display actual version in CLI and startup message

### DIFF
--- a/qwenvert/cli.py
+++ b/qwenvert/cli.py
@@ -15,12 +15,14 @@ import click
 from rich.console import Console
 from rich.table import Table
 
+from . import __version__
+
 
 console = Console()
 
 
 @click.group()
-@click.version_option(version="0.1.0")
+@click.version_option(version=__version__)
 def cli() -> None:
     """
     Qwenvert - One-click local LLM inference for Claude Code.
@@ -226,7 +228,7 @@ def start(auto_install: bool) -> None:
     """
     from .launcher import start_qwenvert_sync
 
-    console.print("\n[bold blue]Starting Qwenvert[/bold blue]\n")
+    console.print(f"\n[bold blue]Starting Qwenvert v{__version__}[/bold blue]\n")
 
     try:
         start_qwenvert_sync()
@@ -764,7 +766,7 @@ def monitor(adapter_url, refresh_rate, enable_otel) -> None:
         try:
             init_telemetry(
                 service_name="qwenvert-monitor",
-                service_version="0.1.0",
+                service_version=__version__,
                 enable_console=False,  # Console exporter would interfere with TUI
                 enable_otlp=False,  # User can enable via env vars if needed
                 enable_prometheus=False,  # User can enable via env vars if needed


### PR DESCRIPTION
## Problem
- `qwenvert --version` showed hardcoded "0.1.0" instead of actual version
- Startup message didn't display version number
- Users couldn't easily verify which version was running

## Solution
✅ Import `__version__` from package `__init__.py`  
✅ Replace all hardcoded "0.1.0" with `__version__`  
✅ Display version in startup message  
✅ Use dynamic version in telemetry

## Changes
**qwenvert/cli.py**:
- Added `from . import __version__`
- Fixed `@click.version_option(version=__version__)`
- Updated startup: `"Starting Qwenvert v{__version__}"`
- Fixed telemetry: `service_version=__version__`

## Testing
```bash
$ qwenvert --version
qwenvert, version 0.2.4

$ qwenvert start
Starting Qwenvert v0.2.4
✓ Servers running...
```

## Fixes
Closes #53 (if issue exists)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Version information now dynamically reflects the actual package version across CLI commands and monitoring features, replacing hard-coded references. Users will see accurate version details in startup messages and telemetry data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->