### PR TITLE
Bump version to 0.2.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ exclude = ["docs*", "benchmarks*", "configs*", "homebrew*"]
 
 [project]
 name = "qwenvert"
-version = "0.2.4"
+version = "0.2.5"
 description = "One-click local LLM inference for Claude Code on Mac M1"
 readme = "README.md"
 requires-python = ">=3.9,<3.13"

--- a/qwenvert/__init__.py
+++ b/qwenvert/__init__.py
@@ -5,7 +5,7 @@ A production-grade inference orchestration system optimized for consumer
 Mac hardware running Qwen models with Claude Code integration.
 """
 
-__version__ = "0.2.4"
+__version__ = "0.2.5"
 __author__ = "Kevin Mesiab"
 
 from .hardware import HardwareDetector, HardwareProfile


### PR DESCRIPTION
## Summary

Version bump from 0.2.4 to 0.2.5

## Changes Since 0.2.4

- **PR #53**: Fix: Display clean error message when port is already in use
  - Add socket-based port availability check before uvicorn bind
  - Use errno.EADDRINUSE constant and context manager to prevent socket leak
  - Show helpful error message with 3 solutions for port conflicts
  - Suppress Python traceback for RuntimeError in CLI

- **PR #54**: Fix: Display actual version in CLI and startup message

## Release Checklist

- [x] Version updated in `pyproject.toml`
- [x] Version updated in `qwenvert/__init__.py`
- [ ] PR approved and merged
- [ ] Tag `v0.2.5` created
- [ ] GitHub Actions publishes to PyPI

## After Merge

Once this PR is merged, the release tag will be created and pushed, which will trigger the GitHub Actions workflow to automatically publish to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)