### PR TITLE
Fix: Suppress noisy health check logs

### DIFF
--- a/qwenvert/launcher.py
+++ b/qwenvert/launcher.py
@@ -356,6 +356,14 @@ class ServerLauncher:
         # Start server in background
         import uvicorn
 
+        # Filter out noisy health check logs
+        class HealthCheckFilter(logging.Filter):
+            """Filter to suppress health check endpoint logs."""
+
+            def filter(self, record: logging.LogRecord) -> bool:
+                """Return False to suppress health check logs."""
+                return "/health" not in record.getMessage()
+
         config = uvicorn.Config(
             app,
             host=self.config.adapter_host,
@@ -364,6 +372,10 @@ class ServerLauncher:
         )
 
         server = uvicorn.Server(config)
+
+        # Apply health check filter to uvicorn's access logger
+        uvicorn_access_logger = logging.getLogger("uvicorn.access")
+        uvicorn_access_logger.addFilter(HealthCheckFilter())
 
         # Run server in asyncio task (non-blocking)
         self.adapter_task = asyncio.create_task(server.serve())


### PR DESCRIPTION
## Summary

Filter out `/health` endpoint requests from uvicorn access logs to reduce log noise during normal operation.

## Problem

Health check endpoints are polled frequently (every 1-2 seconds during startup, then periodically), which floods the logs with messages like:

```
INFO:     127.0.0.1:52209 - "GET /health HTTP/1.1" 200 OK
INFO:     127.0.0.1:52210 - "GET /health HTTP/1.1" 200 OK
INFO:     127.0.0.1:52211 - "GET /health HTTP/1.1" 200 OK
...
```

This makes it difficult to see actual API usage and important log messages.

## Solution

Added a custom `HealthCheckFilter` logging filter that:
- Filters out log records containing `/health` in the message
- Applied to uvicorn's access logger (`uvicorn.access`)
- Preserves all other access logs (actual API calls)

## Changes

**qwenvert/launcher.py:**
- Added `HealthCheckFilter` class (lines 359-365)
- Applied filter to `uvicorn.access` logger (lines 376-378)

## Example

**Before:**
```
INFO:     127.0.0.1:52209 - "GET /health HTTP/1.1" 200 OK
INFO:     127.0.0.1:52210 - "GET /health HTTP/1.1" 200 OK
INFO:     127.0.0.1:52211 - "POST /v1/messages HTTP/1.1" 200 OK
INFO:     127.0.0.1:52212 - "GET /health HTTP/1.1" 200 OK
```

**After:**
```
INFO:     127.0.0.1:52211 - "POST /v1/messages HTTP/1.1" 200 OK
```

## Test Plan

- [x] Syntax validation
- [ ] Manual test: Start qwenvert and verify health check logs are suppressed
- [ ] Manual test: Verify other endpoint logs still appear
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved application log clarity by filtering unnecessary health check messages during adapter startup, reducing log noise without affecting system functionality or performance monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->