### PR TITLE
Remove placeholder Homebrew installation section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,6 @@ Qwenvert lets you use Claude Code CLI with a completely local LLM (Qwen2.5-Coder
 pip install qwenvert
 ```
 
-**Or with Homebrew (coming soon):**
-
-> Homebrew formula is not published yet. See [PUBLISHING.md](./PUBLISHING.md#homebrew) for instructions on creating a Homebrew tap.
-
 **Or install from source:**
 ```bash
 git clone https://github.com/kmesiab/qwenvert.git


### PR DESCRIPTION
## Summary

Removes the "Or with Homebrew (coming soon)" section from the README since the Homebrew formula is not yet published.

## Changes

- Removed lines 37-39 mentioning Homebrew installation
- Removed link to PUBLISHING.md#homebrew 
- Cleaned up installation section to only show published options (PyPI, source)

## Why

- Avoids confusion about unpublished installation methods
- Links to non-existent documentation sections
- Keeps README focused on working installation paths

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed Homebrew installation instructions from the Quick Start section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->