### PR TITLE
Bump version to 0.2.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ exclude = ["docs*", "benchmarks*", "configs*", "homebrew*"]
 
 [project]
 name = "qwenvert"
-version = "0.2.10"
+version = "0.2.11"
 description = "One-click local LLM inference for Claude Code on Mac M1"
 readme = "README.md"
 requires-python = ">=3.9,<3.13"

--- a/qwenvert/__init__.py
+++ b/qwenvert/__init__.py
@@ -5,7 +5,7 @@ A production-grade inference orchestration system optimized for consumer
 Mac hardware running Qwen models with Claude Code integration.
 """
 
-__version__ = "0.2.10"
+__version__ = "0.2.11"
 __author__ = "Kevin Mesiab"
 
 from .hardware import HardwareDetector, HardwareProfile


### PR DESCRIPTION
## Summary

Version bump to 0.2.11 for PyPI release.

This release includes changes from:
- PR #74: Fix for M1/M2/M3/M4 architecture detection (critical bug fix)
- PR #73: Cleanup of temporary markdown files

### Key Improvements in 0.2.11

- **Critical Bug Fix**: M1/M2/M3/M4 architecture detection now works correctly
- **Enhanced Dependency Messaging**: Clearer user feedback during dependency installation
- **Zero-Friction UX**: Auto-install during `qwenvert start` for seamless first-run experience
- **Security Enhancement**: Mandatory checksum verification for all downloads
- **Future-Proof**: Detection logic handles all current and future M-series chips

### Version Consistency

- `pyproject.toml`: 0.2.11
- `qwenvert/__init__.py`: 0.2.11

### Next Steps

After merge:
1. Create GitHub Release with tag `v0.2.11`
2. GitHub Actions will automatically publish to PyPI
3. Verify publication on https://pypi.org/project/qwenvert/

Generated with [Claude Code](https://claude.com/claude-code)