### PR TITLE
chore: Bump version to 0.2.15

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ qwenvert = ["checksums/*.txt", "checksums/*.md"]
 
 [project]
 name = "qwenvert"
-version = "0.2.14"
+version = "0.2.15"
 description = "One-click local LLM inference for Claude Code on Mac M1"
 readme = "README.md"
 requires-python = ">=3.9,<3.13"

--- a/qwenvert/__init__.py
+++ b/qwenvert/__init__.py
@@ -5,7 +5,7 @@ A production-grade inference orchestration system optimized for consumer
 Mac hardware running Qwen models with Claude Code integration.
 """
 
-__version__ = "0.2.14"
+__version__ = "0.2.15"
 __author__ = "Kevin Mesiab"
 
 from .hardware import HardwareDetector, HardwareProfile


### PR DESCRIPTION
Version bump to trigger PyPI publish after v0.2.14 workflow issue.

- Updated pyproject.toml version to 0.2.15
- Updated qwenvert/__init__.py version to 0.2.15

Same functionality as v0.2.14.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.2.15.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->