### PR TITLE
fix: Move checksum generation after PyPI publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -171,18 +171,18 @@ jobs:
           name: python-package-distributions
           path: dist/
 
-      - name: Generate checksums
-        run: |
-          cd dist/
-          # Generate checksums for all distribution files
-          find . -type f \( -name "*.tar.gz" -o -name "*.whl" \) -exec sha256sum {} \; | sed 's|\./||' > SHA256SUMS
-          echo "📋 Generated checksums:"
-          cat SHA256SUMS
-
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           print-hash: true
+
+      - name: Generate checksums
+        run: |
+          cd dist/
+          # Generate checksums for all distribution files (after PyPI publish)
+          find . -type f \( -name "*.tar.gz" -o -name "*.whl" \) -exec sha256sum {} \; | sed 's|\./||' > SHA256SUMS
+          echo "📋 Generated checksums:"
+          cat SHA256SUMS
 
       - name: Upload checksums to release
         if: github.event_name == 'release'


### PR DESCRIPTION
## Problem

PyPI publish is failing with:
```
InvalidDistribution: Unknown distribution format: 'SHA256SUMS'
```

The SHA256SUMS file was being generated in the `dist/` directory BEFORE publishing to PyPI, causing the publish action to try uploading it as a package.

## Solution

Move the "Generate checksums" step to AFTER the "Publish to PyPI" step.

This ensures:
- ✅ Only .whl and .tar.gz files are in dist/ during PyPI upload
- ✅ SHA256SUMS is still generated for release assets
- ✅ No breaking changes to release artifacts

## Testing

- Workflow file validated locally
- No functional changes to checksum generation or release assets
- SHA256SUMS will still be uploaded to GitHub releases

## Fixes

- Unblocks v0.2.15 release
- Unblocks all future PyPI publishes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the release process by streamlining publish operations and checksum generation sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->