### PR TITLE
fix: Fix critical model path bug in llama.cpp launcher (v0.2.16)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ qwenvert = ["checksums/*.txt", "checksums/*.md"]
 
 [project]
 name = "qwenvert"
-version = "0.2.15"
+version = "0.2.16"
 description = "One-click local LLM inference for Claude Code on Mac M1"
 readme = "README.md"
 requires-python = ">=3.9,<3.13"

--- a/qwenvert/__init__.py
+++ b/qwenvert/__init__.py
@@ -5,7 +5,7 @@ A production-grade inference orchestration system optimized for consumer
 Mac hardware running Qwen models with Claude Code integration.
 """
 
-__version__ = "0.2.15"
+__version__ = "0.2.16"
 __author__ = "Kevin Mesiab"
 
 from .hardware import HardwareDetector, HardwareProfile

--- a/qwenvert/config.py
+++ b/qwenvert/config.py
@@ -193,16 +193,23 @@ class ConfigGenerator:
     Generates optimal configurations for backends and qwenvert.
     """
 
-    def __init__(self, model: Model, hardware: HardwareProfile) -> None:
+    def __init__(
+        self,
+        model: Model,
+        hardware: HardwareProfile,
+        model_path: Path | str | None = None,
+    ) -> None:
         """
         Initialize config generator.
 
         Args:
             model: Selected model
             hardware: Detected hardware profile
+            model_path: Actual path to model file (optional, defaults to ~/.qwenvert/models/)
         """
         self.model = model
         self.hardware = hardware
+        self.model_path = model_path
 
     def generate_qwenvert_config(
         self,
@@ -324,9 +331,16 @@ SYSTEM You are a helpful AI coding assistant powered by Qwen2.5-Coder running lo
         # Use performance cores only
         num_threads = self.hardware.cpu_cores_performance
 
+        # Determine model path: use provided path or default location
+        if self.model_path:
+            model_path_str = str(self.model_path)
+        else:
+            # Default to ~/.qwenvert/models/ (where ModelDownloader puts files)
+            model_path_str = f"~/.qwenvert/models/{self.model.backend_model_id}"
+
         flags = [
             "--model",
-            f"~/.cache/qwenvert/models/{self.model.backend_model_id}",
+            model_path_str,
             # GPU offloading - Metal optimization for Apple Silicon
             "-ngl",
             "99",  # Offload all layers to Metal GPU

--- a/qwenvert/launcher.py
+++ b/qwenvert/launcher.py
@@ -236,7 +236,7 @@ class ServerLauncher:
                 model_identifier="Unknown",
             )
 
-        config_gen = ConfigGenerator(model, hardware)
+        config_gen = ConfigGenerator(model, hardware, model_path=self.config.model_path)
         flags = config_gen.generate_llamacpp_flags()
 
         # Start llama-server


### PR DESCRIPTION
## 🚨 CRITICAL HOTFIX for v0.2.15

### Problem

Users running `qwenvert start` after installing v0.2.15 immediately hit:
```
Error: llama.cpp server failed to start
```

This broke the app for **all users** who installed v0.2.15 from PyPI.

### Root Cause

`ConfigGenerator.generate_llamacpp_flags()` had hardcoded path pointing to **wrong directory**:
- **Hardcoded**: `~/.cache/qwenvert/models/` (doesn't exist)
- **Actual location**: `~/.qwenvert/models/` (where ModelDownloader puts files)

The config stored the correct path, but it wasn't being used.

### Fix

1. **Updated ConfigGenerator** to accept optional `model_path` parameter
2. **Updated generate_llamacpp_flags()** to use `model_path` if provided, else fall back to correct default
3. **Updated ServerLauncher** to pass `config.model_path` to ConfigGenerator

### Changes

- `qwenvert/config.py`: Add `model_path` parameter to `ConfigGenerator.__init__()`
- `qwenvert/config.py`: Use `model_path` in `generate_llamacpp_flags()`
- `qwenvert/launcher.py`: Pass `config.model_path` to `ConfigGenerator`
- Version bump: `0.2.15` → `0.2.16`

### Testing

✅ All 547 tests pass
✅ Manual test: `qwenvert start` works, both ports listening (8080, 8088)
✅ llama-server starts successfully with correct model path

### Impact

- Unblocks all users who installed v0.2.15
- No API changes, backward compatible
- Critical production fix

### Release Plan

1. Merge this PR
2. Tag as `v0.2.16`
3. Publish to PyPI immediately

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional model_path configuration parameter to specify custom model file locations instead of using the default directory.

* **Chores**
  * Version bumped to 0.2.16.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->